### PR TITLE
DNM: Ammend apollo-server-express-api example to show how to use playgroun…

### DIFF
--- a/src/examples/apollo-server-express-api.ts
+++ b/src/examples/apollo-server-express-api.ts
@@ -33,7 +33,12 @@ const apolloServerConfig = FanoutGraphqlApolloConfig({
     ...webSocketOverHttpStorage,
   },
 });
-const apolloServer = new ApolloServer(apolloServerConfig);
+const apolloServer = new ApolloServer({
+  ...apolloServerConfig,
+  playground: {
+    cdnUrl: "http://graphql-playground-cdn.fanout.io",
+  }
+});
 
 const PORT = process.env.PORT || 4000;
 const app = express().use(


### PR DESCRIPTION
…d.cdnUrl

When I run that ammended script with `./node_modules/.bin/ts-node src/examples/apollo-server-express-api.ts` and then open in web browser http://localhost:4000/graphql, the web console shows failed requests to the cdnUrl value of http://graphql-playground-cdn.fanout.io
