### PR TITLE
tests that require running pushpin no longer run on 'npm test' unless…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,7 @@
       "sourceMaps": true,
       "env": {
         "LOG_LEVEL": "debug",
+        "PUSHPIN_PROXY_URL": "http://localhost:7999",
         "TEST_TIMEOUT_MS": "60000"
       }
     },

--- a/src/FanoutGraphqlAppLambdaCallbackTest.test.ts
+++ b/src/FanoutGraphqlAppLambdaCallbackTest.test.ts
@@ -1,6 +1,6 @@
 import * as pulumiAws from "@pulumi/aws";
 import * as pulumiAwsx from "@pulumi/awsx";
-import { AsyncTest, Expect, TestFixture } from "alsatian";
+import { AsyncTest, Expect, FocusTest, TestFixture } from "alsatian";
 import { APIGatewayProxyEvent, Handler } from "aws-lambda";
 import { MapSimpleTable } from "fanout-graphql-tools";
 import {

--- a/src/FanoutGraphqlExpressServerTest.test.ts
+++ b/src/FanoutGraphqlExpressServerTest.test.ts
@@ -26,7 +26,7 @@ import {
   apolloServerInfo,
   FanoutGraphqlExpressServer,
 } from "./FanoutGraphqlExpressServer";
-import { cli } from "./test/cli";
+import { cli, DecorateIf } from "./test/cli";
 import {
   FanoutGraphqlHttpAtUrlTest,
   itemsFromLinkObservable,
@@ -177,9 +177,13 @@ export class FanoutGraphqlExpressServerTestSuite {
    */
   @AsyncTest()
   @Timeout(1000 * 60 * 10)
+  @DecorateIf(
+    () => !Boolean(process.env.PUSHPIN_PROXY_URL),
+    IgnoreTest("process.env.PUSHPIN_PROXY_URL is not defined"),
+  )
   public async testFanoutGraphqlExpressServerThroughPushpin(
     graphqlPort = 57410,
-    pushpinProxyUrl = "http://localhost:7999",
+    pushpinProxyUrl = process.env.PUSHPIN_PROXY_URL || "http://localhost:7999",
     pushpinGripUrl = "http://localhost:5561",
   ) {
     const [setLatestSocket, _, socketChangedEvent] = ChangingValue();
@@ -219,11 +223,18 @@ export class FanoutGraphqlExpressServerTestSuite {
    */
   @AsyncTest()
   @Timeout(1000 * 60 * 10)
+  @DecorateIf(
+    () => !Boolean(process.env.PUSHPIN_PROXY_URL),
+    IgnoreTest("process.env.PUSHPIN_PROXY_URL is not defined"),
+  )
   public async testFanoutGraphqlExpressServerThroughPushpinDeletesSubscriptionAfterGqlWsStop(
     graphqlPort = 57410,
-    pushpinProxyUrl = "http://localhost:7999",
+    pushpinProxyUrl = process.env.PUSHPIN_PROXY_URL,
     pushpinGripUrl = "http://localhost:5561",
   ) {
+    if ( ! pushpinProxyUrl) {
+      throw new Error(`pushpinProxyUrl is required for this test, but got ${pushpinProxyUrl}`)
+    }
     const [setLatestSocket, _, socketChangedEvent] = ChangingValue();
     const [
       setLastSubscriptionStop,
@@ -286,9 +297,13 @@ export class FanoutGraphqlExpressServerTestSuite {
 
   /** Test with a raw WebSocket client and make sure that subscriptions are cleaned up after WebSocket#close() */
   @AsyncTest()
+  @DecorateIf(
+    () => !Boolean(process.env.PUSHPIN_PROXY_URL),
+    IgnoreTest("process.env.PUSHPIN_PROXY_URL is not defined"),
+  )
   public async testFanoutGraphqlExpressServerThroughPushpinAndTestSubscriptionsDeletedAfterConnectionClose(
     graphqlPort = 57410,
-    pushpinProxyUrl = "http://localhost:7999",
+    pushpinProxyUrl = process.env.PUSHPIN_PROXY_URL || "http://localhost:7999",
     pushpinGripUrl = "http://localhost:5561",
   ) {
     //

--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -43,6 +43,21 @@ async function main(filename?: string): Promise<void> {
   await testRunner.run(testSet, timeout);
 }
 
+type Decorator = (
+  target: object,
+  propertyKey: string,
+  descriptor?: TypedPropertyDescriptor<any>,
+) => void;
+/** Conditionally apply a decorator */
+export function DecorateIf(test: () => boolean, decorator: Decorator): Decorator {
+  if (test()) {
+    return decorator;
+  }
+  return () => {
+    return;
+  };
+}
+
 if (require.main === module) {
   main().catch(error => {
     throw error;


### PR DESCRIPTION
… env var PUSHPIN_PROXY_URL is set (so that travis can run other tests that dont reuqire pushpin)