### PR TITLE
Fix now dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "fanout-apollo-demo",
   "devDependencies": {
     "@types/node": "latest",
@@ -54,6 +55,7 @@
   },
   "scripts": {
     "build": "npm run tsc",
+    "now-build": "echo 'skipping build step'",
     "prettier": "prettier '{package.json,tsconfig.json,api/**/*.{ts,tsx}}' --write",
     "start": "ts-node api/index",
     "test": "ts-node api/_test/unit",


### PR DESCRIPTION
The `build` script in package.json was invoking `tsc` but ZEIT Now already builds `.ts` files so this was building twice.

The solution is to define `now-build` script which takes precedence over the `build` script.

I also added `private: true` to prevent npm warnings about missing license or repository. I don't believe you intend to publish this application to npm so this is typically a good safe-guard too.